### PR TITLE
Make Garaga Zero importable as a uv package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,27 @@ dependencies = [
 "pre-commit",
 ]
 
+[tool.uv.source]
+garaga = { git = "https://github.com/keep-starknet-strange/garaga.git", rev = "hydra_upd" }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+include = [
+  "**/*.py",
+  "src/**/*.cairo", # Include all .cairo files in src directory
+]
+packages = ["."]
+
+[tool.hatch.build]
+artifacts = [
+  "src/**/*.cairo", # Also include .cairo files as artifacts
+]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.isort]
 profile = "black"
@@ -22,7 +43,7 @@ profile = "black"
 cache_dir = "build/.pytest_cache"
 testpaths = ["tests/hydra"]
 # addopts = "--tb=short --showlocals"
-asyncio_default_fixture_loop_scope = "function"  # Explicitly set the loop scope
+asyncio_default_fixture_loop_scope = "function" # Explicitly set the loop scope
 
 [tool.black]
 line-length = 88

--- a/src/bls12_381/final_exp.cairo
+++ b/src/bls12_381/final_exp.cairo
@@ -28,7 +28,14 @@ func final_exponentiation{
         v0=input.w1, v1=input.w3, v2=input.w5, v3=input.w7, v4=input.w9, v5=input.w11
     );
     let (local circuit_input: felt*) = alloc();
-    memcpy(dst=circuit_input, src=cast(&num, felt*), len=24);
+
+    let (num_is_zero) = is_zero_E6D(num, bls.CURVE_ID);
+    if (num_is_zero == TRUE) {
+        let (one_E12: E12D) = one_E12D();
+        return (res=one_E12);
+    } else {
+        memcpy(dst=circuit_input, src=cast(&num, felt*), len=24);
+    }
 
     let (den_is_zero) = is_zero_E6D(den, bls.CURVE_ID);
     if (den_is_zero == TRUE) {

--- a/src/bn254/final_exp.cairo
+++ b/src/bn254/final_exp.cairo
@@ -28,7 +28,14 @@ func final_exponentiation{
         v0=input.w1, v1=input.w3, v2=input.w5, v3=input.w7, v4=input.w9, v5=input.w11
     );
     let (local circuit_input: felt*) = alloc();
-    memcpy(dst=circuit_input, src=cast(&num, felt*), len=24);
+
+    let (num_is_zero) = is_zero_E6D(num, bn.CURVE_ID);
+    if (num_is_zero == TRUE) {
+        let (one_E12: E12D) = one_E12D();
+        return (res=one_E12);
+    } else {
+        memcpy(dst=circuit_input, src=cast(&num, felt*), len=24);
+    }
 
     let (den_is_zero) = is_zero_E6D(den, bn.CURVE_ID);
     if (den_is_zero == TRUE) {

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -30,7 +30,7 @@ func hash_full_transcript_and_get_Z_3_LIMBS{poseidon_ptr: PoseidonBuiltin*}(
     //         print(f"Will Hash {hex(e)}")
     // %}
 
-    let elements_end = &limbs_ptr[n * N_LIMBS];
+    local elements_end: felt* = &limbs_ptr[n * N_LIMBS];
 
     tempvar elements = limbs_ptr;
     tempvar pos_ptr = cast(poseidon_ptr, felt*);
@@ -113,7 +113,7 @@ func hash_full_transcript_and_get_Z_4_LIMBS{poseidon_ptr: PoseidonBuiltin*}(
     //     for e in to_hash:
     //         print(f"Will Hash {hex(e)}")
     // %}
-    let elements_end = &limbs_ptr[n * N_LIMBS];
+    local elements_end: felt* = &limbs_ptr[n * N_LIMBS];
 
     tempvar elements = limbs_ptr;
     tempvar pos_ptr = cast(poseidon_ptr, felt*);


### PR DESCRIPTION
Setups `pyproject.toml` to make Garaga-Zero importable in `uv` projects.

Used a `local` variable to keep `elements_end` instead of a `let` because the RustVM is bugged when it comes to tracking `let` references in hints.

This makes Garaga Zero usable with Keth, running on the Rust VM !