### PR TITLE
chore: let -> local to make compatible with rustvm runs

### DIFF
--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -30,7 +30,7 @@ func hash_full_transcript_and_get_Z_3_LIMBS{poseidon_ptr: PoseidonBuiltin*}(
     //         print(f"Will Hash {hex(e)}")
     // %}
 
-    let elements_end = &limbs_ptr[n * N_LIMBS];
+    local elements_end: felt* = &limbs_ptr[n * N_LIMBS];
 
     tempvar elements = limbs_ptr;
     tempvar pos_ptr = cast(poseidon_ptr, felt*);
@@ -113,7 +113,7 @@ func hash_full_transcript_and_get_Z_4_LIMBS{poseidon_ptr: PoseidonBuiltin*}(
     //     for e in to_hash:
     //         print(f"Will Hash {hex(e)}")
     // %}
-    let elements_end = &limbs_ptr[n * N_LIMBS];
+    local elements_end: felt* = &limbs_ptr[n * N_LIMBS];
 
     tempvar elements = limbs_ptr;
     tempvar pos_ptr = cast(poseidon_ptr, felt*);


### PR DESCRIPTION
make a `let` a `local` so that it's accessible from the hint execution on the RustVM. The problem being that the way they process hint identifiers is bugged and is not returning the proper value